### PR TITLE
Add support for applying a keyword-fn as we go

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
             :license {:name "Eclipse Public License"
                       :url "http://www.eclipse.org/legal/epl-v10.html"
                       :comments "Same as Clojure"}
-            :dependencies [[org.clojure/clojure "1.4.0"]
+            :dependencies [[org.clojure/clojure "1.5.0"]
                            [joda-time "1.6"]
                            [commons-codec/commons-codec "1.4"]])

--- a/src/com/github/bdesham/clj_plist.clj
+++ b/src/com/github/bdesham/clj_plist.clj
@@ -3,6 +3,9 @@
            (org.joda.time DateTime))
   (:require clojure.xml))
 
+(def ^:private ^:dynamic *keyword-fn*
+  identity)
+
 (defn- first-content
   [c]
   (first (c :content)))
@@ -35,7 +38,7 @@
 
 (defmethod content :key
   [c]
-  (first-content c))
+  (*keyword-fn* (first-content c)))
 
 (defmethod content :real
   [c]
@@ -50,5 +53,8 @@
   true)
 
 (defn parse-plist
-  [source]
-  (content (first-content (clojure.xml/parse source))))
+  ([source]
+   (content (first-content (clojure.xml/parse source))))
+  ([source {:keys [keyword-fn]}]
+   (binding [*keyword-fn* keyword-fn]
+     (parse-plist source))))

--- a/src/com/github/bdesham/clj_plist.clj
+++ b/src/com/github/bdesham/clj_plist.clj
@@ -7,11 +7,11 @@
   [c]
   (first (c :content)))
 
-(defmulti content (fn [c] (c :tag)))
+(defmulti content :tag)
 
 (defmethod content :array
   [c]
-  (apply vector (for [item (c :content)] (content item))))
+  (apply vector (map content (c :content))))
 
 (defmethod content :data
   [c]
@@ -23,7 +23,7 @@
 
 (defmethod content :dict
   [c]
-  (apply hash-map (for [item (c :content)] (content item))))
+  (apply hash-map (map content (c :content))))
 
 (defmethod content :false
   [c]


### PR DESCRIPTION
Hi!

This does two things:

1. Allows you to pass something like `#(-> % str str/lower-case (str/replace #"\s+" "-") keyword)` into `parse-plist` to be applied to all of the keys in the plist, so you end up with a map like `{:key-name v}` instead of `{"Key Name" v}`, for example.

    Of course, this could be done afterwards with something like `clojure.walk/keywordize-keys`, but this way allows for arbitrary keyword-fns and doesn't require a second walking of the tree. The keyword-fn defaults to `identity`, which has minimal overhead.

2. Unrelated, I discovered that sometimes (malformed?) plists can have dicts with duplicate keys. Currently this blows up the parser, because the `hash-map` constructor didn't allow duplicate keys before Clojure 1.5 (2013). I bumped the Clojure version for the project so that parsing such plists works now -- it just uses the last value for the key. This is an imperfect solution but I think it's better than flat-out failing?

What do you think?

Cheers,
Ben