### PR TITLE
Add CI using CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  java:
+    version: oraclejdk8
+general:
+  artifacts:
+    - target/coverage
+test:
+  pre:
+    - mkdir $CIRCLE_TEST_REPORTS/lein
+  override:
+    - lein test-out junit $CIRCLE_TEST_REPORTS/lein/results.xml

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,5 @@
                       :comments "Same as Clojure"}
             :dependencies [[org.clojure/clojure "1.5.0"]
                            [joda-time "1.6"]
-                           [commons-codec/commons-codec "1.4"]])
+                           [commons-codec/commons-codec "1.4"]]
+            :plugins [[lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]])


### PR DESCRIPTION
This adds circleci test support to the repo – see https://circleci.com/gh/circleci/clj-plist/6 for an example build.